### PR TITLE
Fix Playwright iOS real device validation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.2.0",
-    "@playwright/test": "^1.55.0",
-    "expect": "^30.1.2",
-    "playwright": "^1.55.0",
-    "dotenv": "^17.2.2"
+    "dotenv": "^17.2.2",
+    "expect": "^30.1.2"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.57.0",
+    "playwright": "^1.57.0"
   }
-
 }

--- a/playwright-ios-real-device.js
+++ b/playwright-ios-real-device.js
@@ -28,68 +28,89 @@ const { expect } = require("expect");
   console.log('Platform: iOS 18, Device: iPhone 16');
 
   let browser = await webkit.connect(
-      `wss://cdp.lambdatest.com/playwright?capabilities=${encodeURIComponent(
-          JSON.stringify(capabilities))}`,
+    `wss://cdp.lambdatest.com/playwright?capabilities=${encodeURIComponent(
+      JSON.stringify(capabilities)
+    )}`,
   );
 
   console.log('Connected to iOS device successfully!');
-  console.log(`Device: iPhone 16, iOS 18`);
+  console.log('Device: iPhone 16, iOS 18');
 
   console.log('Creating browser context...');
   let context = await browser.newContext({
-    hasTouch: true,  // Enable touch support for iOS
-    isMobile: true   // Enable mobile mode for iOS
+    hasTouch: true,
+    isMobile: true
   });
+
   let page = await context.newPage();
 
   console.log('Navigating to Wikipedia...');
   await page.goto('https://www.wikipedia.org/', { timeout: 30000 });
-  
+
   console.log('Finding search input...');
   let element = await page.locator('input[name="search"]');
-  
+
   console.log('Clicking search input...');
   await element.click();
-  
+
   console.log('Typing "playwright"...');
   await element.fill('playwright');
-  
-  console.log('Clicking search input again...');
-  await element.click();
-  
-  console.log('Current URL:', await page.url());
-  
+
   console.log('Finding and clicking search button...');
   await page.locator('#search-form > fieldset > button').click();
-  
-  console.log('Waiting for search results...');
-  await page.waitForTimeout(3000);
-  
-  console.log('Counting occurrences of "19th century"...');
-  const count = await page.getByText('19th century').count();
-  console.log('Found', count, 'occurrences of "19th century"');
-  
+
+  console.log('Waiting for article page...');
+  await page.waitForLoadState('networkidle');
+
   try {
-    console.log('Verifying count...');
-    expect(count).toEqual(3);
+    console.log('Verifying article heading...');
+    
+    const heading = page.locator('#firstHeading');
+    await heading.waitFor({ state: 'visible', timeout: 10000 });
+
+    const headingText = await heading.textContent();
+    console.log('Article heading:', headingText);
+
+    expect(headingText.toLowerCase()).toContain('playwright');
+
     console.log('iOS Test PASSED!');
-    
-    // Mark the test as completed or failed
-    await page.evaluate(_ => {}, `lambdatest_action: ${JSON.stringify({ action: "setTestStatus", arguments: {status: "passed", remark: "Wikipedia test passed - found 3 occurrences of '19th century'" },})}`);
+
+    await page.evaluate(
+      _ => {},
+      `lambdatest_action: ${JSON.stringify({
+        action: "setTestStatus",
+        arguments: {
+          status: "passed",
+          remark: "Wikipedia Playwright article loaded successfully"
+        },
+      })}`
+    );
+
     console.log('Marked test as PASSED in LambdaTest dashboard');
-    
-    await teardown(page, context, browser)
+
+    await teardown(page, context, browser);
+
   } catch (e) {
+
     console.log('iOS Test FAILED!');
     console.log('Error:', e.message);
-    console.log('Expected: 3 occurrences of "19th century"');
-    console.log('Actual count:', count);
-    
-    await page.evaluate(_ => {}, `lambdatest_action: ${JSON.stringify({action: "setTestStatus", arguments: { status: "failed", remark: e.message }})}`);
+
+    await page.evaluate(
+      _ => {},
+      `lambdatest_action: ${JSON.stringify({
+        action: "setTestStatus",
+        arguments: {
+          status: "failed",
+          remark: e.message
+        }
+      })}`
+    );
+
     console.log('Marked test as FAILED in LambdaTest dashboard');
-    
-    await teardown(page, context, browser)
-    throw e.stack
+
+    await teardown(page, context, browser);
+
+    throw e;
   }
 
 })().catch(err => {
@@ -100,31 +121,31 @@ const { expect } = require("expect");
 
 async function teardown(page, context, browser) {
   console.log('Cleaning up iOS test resources...');
+
   try {
-    console.log('   Closing page...');
+    console.log('Closing page...');
     await Promise.race([
       page.close(),
-      new Promise(resolve => setTimeout(resolve, 10000)) // 10 second timeout
+      new Promise(resolve => setTimeout(resolve, 10000))
     ]);
-    console.log('   Page closed');
-    
-    console.log('   Closing context...');
+
+    console.log('Closing context...');
     await Promise.race([
       context.close(),
-      new Promise(resolve => setTimeout(resolve, 10000)) // 10 second timeout
+      new Promise(resolve => setTimeout(resolve, 10000))
     ]);
-    console.log('   Context closed');
-    
-    console.log('   Closing browser connection...');
+
+    console.log('Closing browser connection...');
     await Promise.race([
       browser.close(),
-      new Promise(resolve => setTimeout(resolve, 15000)) // 15 second timeout for browser
+      new Promise(resolve => setTimeout(resolve, 15000))
     ]);
-    console.log('   Browser closed');
-    
+
     console.log('iOS test completed and resources cleaned up!');
+
   } catch (error) {
     console.log('Cleanup completed with warnings:', error.message);
   }
-    process.exit(0);
-} 
+
+  process.exit(0);
+}


### PR DESCRIPTION
Updated the iOS real device Playwright sample to use a more stable validation strategy.

Changes:
- Replaced brittle text-count assertion
- Added heading-based validation for Playwright article
- Improved reliability on mobile Safari/iOS rendering
- Updated Playwright dependency compatibility

Tested successfully on:
- iPhone 16
- iOS 18
- Playwright 1.57.0