### PR TITLE
Fix parallel test: move off unsupported macOS Big Sur (CDP grid 500)

### DIFF
--- a/playwright-parallel.js
+++ b/playwright-parallel.js
@@ -99,9 +99,9 @@ const capabilities = [
     'browserName': 'MicrosoftEdge',
     'browserVersion': 'latest',
     'LT:Options': {
-      'platform': 'MacOS Ventura',
+      'platform': 'macOS Ventura',
       'build': 'Playwright With Parallel Build',
-      'name': 'Playwright Sample Test on Windows 8 - MicrosoftEdge',
+      'name': 'Playwright Sample Test on macOS Ventura - MicrosoftEdge',
       'user': process.env.LT_USERNAME,
       'accessKey': process.env.LT_ACCESS_KEY,
       'network': true,
@@ -114,9 +114,9 @@ const capabilities = [
     'browserName': 'Chrome',
     'browserVersion': 'latest',
     'LT:Options': {
-      'platform': 'MacOS Big sur',
+      'platform': 'macOS Sonoma',
       'build': 'Playwright With Parallel Build',
-      'name': 'Playwright Sample Test on MacOS Big sur - Chrome',
+      'name': 'Playwright Sample Test on macOS Sonoma - Chrome',
       'user': process.env.LT_USERNAME,
       'accessKey': process.env.LT_ACCESS_KEY,
       'network': true,


### PR DESCRIPTION
## Problem

`playwright-single.js` passes, but `playwright-parallel.js` fails. One of its three capabilities — **Chrome on `MacOS Big sur`** — cannot be provisioned on the Playwright CDP grid:
```
browserType.connect: WebSocket error: wss://cdp.lambdatest.com/playwright 500 Internal Server Error
{"message":"... failed to setup CDP grid: non-200 status code: 500"}
```
I isolated each capability against live LambdaTest: Chrome/Big Sur **500s even with correct casing** (`macOS Big Sur`), while Chrome/Ventura, Chrome/Sonoma and Edge/Ventura all connect fine. macOS Big Sur (macOS 11, 2020) is effectively retired for Playwright on the grid — this is not transient.

## Change

- Move the failing capability from `MacOS Big sur` → **`macOS Sonoma`** (verified working).
- Correct the Edge capability's platform casing `MacOS Ventura` → `macOS Ventura` and fix its mislabeled name (`Windows 8` → `macOS Ventura`).

## Verification

Ran `node playwright-parallel.js` live on LambdaTest — **all three capabilities pass**, exit 0:
```
Test PASSED ... macOS Sonoma - Chrome
Test PASSED ... Windows 10 - Chrome
Test PASSED ... macOS Ventura - MicrosoftEdge
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)